### PR TITLE
Create entry-gamemode and exit-gamemode flags

### DIFF
--- a/src/com/kicas/rp/command/CommandRegion.java
+++ b/src/com/kicas/rp/command/CommandRegion.java
@@ -703,6 +703,11 @@ public class CommandRegion extends TabCompleterBase implements CommandExecutor {
 
             case ENTRANCE_RESTRICTION:
                 return filterFormat(args[4], Arrays.stream(BorderPolicy.Policy.VALUES), Utils::formattedName);
+
+            // Suggest gamemodes
+            case ENTRY_GAMEMODE:
+            case EXIT_GAMEMODE:
+                return filterFormat(args[4], Arrays.stream(GameModeMeta.Mode.VALUES), Utils::formattedName);
         }
 
         return Collections.emptyList();

--- a/src/com/kicas/rp/data/Deserializer.java
+++ b/src/com/kicas/rp/data/Deserializer.java
@@ -214,6 +214,8 @@ public class Deserializer implements AutoCloseable {
                 meta = decoder.readBoolean();
             else if (BorderPolicy.class.equals(flag.getMetaClass()))
                 meta = new BorderPolicy(BorderPolicy.Policy.VALUES[decoder.read()]);
+            else if (GameModeMeta.class.equals(flag.getMetaClass()))
+                meta = new GameModeMeta(GameModeMeta.Mode.VALUES[decoder.read()]);
             else if (CommandMeta.class.equals(flag.getMetaClass()))
                 meta = new CommandMeta(decoder.readBoolean(), decoder.readUTF8Raw());
             else if (EnumFilter.class.isAssignableFrom(flag.getMetaClass())) {

--- a/src/com/kicas/rp/data/RegionFlag.java
+++ b/src/com/kicas/rp/data/RegionFlag.java
@@ -72,7 +72,9 @@ public enum RegionFlag {
     RIPTIDE,
     FARMLAND_MOISTURE_CHANGE,
     ENTRANCE_RESTRICTION(BorderPolicy.class),
-    FIRE_TICK(true);
+    FIRE_TICK(true),
+    ENTRY_GAMEMODE(GameModeMeta.class),
+    EXIT_GAMEMODE(GameModeMeta.class);
 
     public static final RegionFlag[] VALUES = values();
     private static final Map<RegionFlag, Pair<Object, Function<World, Object>>> DEFAULT_VALUES = new HashMap<>();
@@ -256,6 +258,8 @@ public enum RegionFlag {
         registerDefault(ENTRANCE_RESTRICTION, BorderPolicy.NONE);
         registerDefault(FIRE_TICK, config.getBoolean("world.fire-tick"),
                 world -> world.getGameRuleValue(GameRule.DO_FIRE_TICK));
+        registerDefault(ENTRY_GAMEMODE, null);
+        registerDefault(EXIT_GAMEMODE, null);
     }
 
     /**

--- a/src/com/kicas/rp/data/Serializer.java
+++ b/src/com/kicas/rp/data/Serializer.java
@@ -126,6 +126,8 @@ public class Serializer implements AutoCloseable {
             encoder.writeBoolean((boolean) meta);
         else if (meta instanceof BorderPolicy)
             encoder.write(((BorderPolicy) meta).getPolicy().ordinal());
+        else if (meta instanceof GameModeMeta)
+            encoder.write(((GameModeMeta) meta).getMode().ordinal());
         else if (meta instanceof CommandMeta) {
             encoder.writeBoolean(((CommandMeta) meta).runFromConsole());
             encoder.writeUTF8Raw(((CommandMeta) meta).getCommand());

--- a/src/com/kicas/rp/data/flagdata/GameModeMeta.java
+++ b/src/com/kicas/rp/data/flagdata/GameModeMeta.java
@@ -1,0 +1,52 @@
+package com.kicas.rp.data.flagdata;
+
+import com.kicas.rp.util.Utils;
+import org.bukkit.GameMode;
+
+/**
+ * Allows for gamemode data to be stored.  Used in entry/exit gamemode flags.
+ */
+public class GameModeMeta extends FlagMeta {
+    private Mode mode;
+
+    public GameModeMeta(Mode mode) {
+        this.mode = mode;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    /**
+     * Update the gamemode change (creative, survival, adventure, or spectator) of this border based off of
+     * the given string("creative", "survival", "adventure", or "spectator").
+     *
+     * @param metaString "creative", "survival", "adventure", or "spectator".
+     */
+    public void readMetaString(String metaString) {
+        Mode mode = Utils.valueOfFormattedName(metaString, Mode.class);
+        if (mode == null)
+            throw new IllegalArgumentException("Invalid gamemode: \"" + metaString + "\"");
+        this.mode = mode;
+    }
+
+    /**
+     * @return the formatted name of this gamemode change.
+     */
+    public String toMetaString() {
+        return Utils.formattedName(mode);
+    }
+
+    /**
+     * @return the GameMode of this gamemode change.
+     */
+    public GameMode toGameMode(){
+        return GameMode.valueOf(Utils.formattedName(mode).toUpperCase());
+    }
+
+    public enum Mode {
+        ADVENTURE, CREATIVE, SPECTATOR, SURVIVAL;
+
+        public static final Mode[] VALUES = values();
+    }
+}

--- a/src/com/kicas/rp/event/PlayerEventHandler.java
+++ b/src/com/kicas/rp/event/PlayerEventHandler.java
@@ -771,6 +771,10 @@ public class PlayerEventHandler implements Listener {
                 event.setKeepLevel(true);
                 event.setDroppedExp(0);
             }
+
+            if(!flags.isEffectiveOwner(event.getEntity()) && flags.hasFlag(RegionFlag.EXIT_GAMEMODE)) {
+                event.getEntity().setGameMode(flags.<GameModeMeta>getFlagMeta(RegionFlag.EXIT_GAMEMODE).toGameMode());
+            }
         }
     }
 
@@ -787,19 +791,20 @@ public class PlayerEventHandler implements Listener {
         if (flags != null){
             if(flags.hasFlag(RegionFlag.RESPAWN_LOCATION)) {
                 event.setRespawnLocation(flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation()); // RESPAWN_LOCATION flag
+
+                FlagContainer respawnFlags = RegionProtection.getDataManager().getFlagsAt(
+                        flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation()); // Flags for region of respawn
+                if(respawnFlags != null && respawnFlags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) { // Respawns inside a region, set gamemode to ENTRY_GAMEMODE flag
+                    if (!respawnFlags.equals(flags) && !respawnFlags.isEffectiveOwner(event.getPlayer()) && respawnFlags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) { // ENTRY_GAMEMODE flag
+                        event.getPlayer().setGameMode(respawnFlags.<GameModeMeta>getFlagMeta(RegionFlag.ENTRY_GAMEMODE).toGameMode());
+                    }
+                }else{ // Respawns outside a region, set gamemode to EXIT_GAMEMODE flag
+                    if (flags.hasFlag(RegionFlag.EXIT_GAMEMODE)) {
+                        event.getPlayer().setGameMode(flags.<GameModeMeta>getFlagMeta(RegionFlag.EXIT_GAMEMODE).toGameMode());
+                    }
+                }
             }
 
-            FlagContainer respawnFlags = RegionProtection.getDataManager().getFlagsAt(
-                    flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation()); // Flags for region of respawn
-            if(respawnFlags != null) { // Respawns inside a region, set gamemode to ENTRY_GAMEMODE flag
-                if (!respawnFlags.equals(flags) && !respawnFlags.isEffectiveOwner(event.getPlayer()) && respawnFlags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) { // ENTRY_GAMEMODE flag
-                    event.getPlayer().setGameMode(respawnFlags.<GameModeMeta>getFlagMeta(RegionFlag.ENTRY_GAMEMODE).toGameMode());
-                }
-            }else{ // Respawns outside a region, set gamemode to EXIT_GAMEMODE flag
-                if (flags.hasFlag(RegionFlag.EXIT_GAMEMODE)) {
-                    event.getPlayer().setGameMode(flags.<GameModeMeta>getFlagMeta(RegionFlag.EXIT_GAMEMODE).toGameMode());
-                }
-            }
         }
 
     }

--- a/src/com/kicas/rp/event/PlayerEventHandler.java
+++ b/src/com/kicas/rp/event/PlayerEventHandler.java
@@ -776,6 +776,7 @@ public class PlayerEventHandler implements Listener {
 
     /**
      * Handles artificial respawn location.
+     * Handles gamemode changes when respawning.
      *
      * @param event the event.
      */
@@ -783,8 +784,24 @@ public class PlayerEventHandler implements Listener {
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         FlagContainer flags = RegionProtection.getDataManager().getFlagsAt(event.getPlayer().getLocation());
 
-        if (flags != null && flags.hasFlag(RegionFlag.RESPAWN_LOCATION))
-            event.setRespawnLocation(flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation());
+        if (flags != null){
+            if(flags.hasFlag(RegionFlag.RESPAWN_LOCATION)) {
+                event.setRespawnLocation(flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation()); // RESPAWN_LOCATION flag
+            }
+
+            FlagContainer respawnFlags = RegionProtection.getDataManager().getFlagsAt(
+                    flags.<LocationMeta>getFlagMeta(RegionFlag.RESPAWN_LOCATION).getLocation()); // Flags for region of respawn
+            if(respawnFlags != null) { // Respawns inside a region, set gamemode to ENTRY_GAMEMODE flag
+                if (!respawnFlags.equals(flags) && !respawnFlags.isEffectiveOwner(event.getPlayer()) && respawnFlags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) { // ENTRY_GAMEMODE flag
+                    event.getPlayer().setGameMode(respawnFlags.<GameModeMeta>getFlagMeta(RegionFlag.ENTRY_GAMEMODE).toGameMode());
+                }
+            }else{ // Respawns outside a region, set gamemode to EXIT_GAMEMODE flag
+                if (flags.hasFlag(RegionFlag.EXIT_GAMEMODE)) {
+                    event.getPlayer().setGameMode(flags.<GameModeMeta>getFlagMeta(RegionFlag.EXIT_GAMEMODE).toGameMode());
+                }
+            }
+        }
+
     }
 
     /**
@@ -905,11 +922,18 @@ public class PlayerEventHandler implements Listener {
 
         if (!Objects.equals(fromFlags, toFlags)) {
             if (toFlags != null) {
-                if (!toFlags.getFlagMeta(RegionFlag.GREETING).equals(fromFlags == null ? null : fromFlags.getFlagMeta(RegionFlag.GREETING)))
+                if (!toFlags.getFlagMeta(RegionFlag.GREETING).equals(fromFlags == null ? null : fromFlags.getFlagMeta(RegionFlag.GREETING))) {
                     toFlags.<TextMeta>getFlagMeta(RegionFlag.GREETING).sendTo(player);
+                }
 
-                if (toFlags.hasFlag(RegionFlag.ENTER_COMMAND))
+                if (toFlags.hasFlag(RegionFlag.ENTER_COMMAND)) {
                     toFlags.<CommandMeta>getFlagMeta(RegionFlag.ENTER_COMMAND).execute(player);
+                }
+
+                if(!toFlags.isEffectiveOwner(player) && toFlags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) {
+                    player.setGameMode(toFlags.<GameModeMeta>getFlagMeta(RegionFlag.ENTRY_GAMEMODE).toGameMode());
+
+                }
 
                 if (!toFlags.isEffectiveOwner(player) && !toFlags.isAllowed(RegionFlag.ELYTRA_FLIGHT) && player.isGliding()) {
                     player.setGliding(false);
@@ -940,17 +964,23 @@ public class PlayerEventHandler implements Listener {
             }
 
             if (fromFlags != null) {
-                if (!fromFlags.getFlagMeta(RegionFlag.FAREWELL).equals(toFlags == null ? null : toFlags.getFlagMeta(RegionFlag.FAREWELL)))
+                if (!fromFlags.getFlagMeta(RegionFlag.FAREWELL).equals(toFlags == null ? null : toFlags.getFlagMeta(RegionFlag.FAREWELL))) {
                     fromFlags.<TextMeta>getFlagMeta(RegionFlag.FAREWELL).sendTo(player);
+                }
 
                 if (fromFlags.hasFlag(RegionFlag.EXIT_COMMAND))
                     fromFlags.<CommandMeta>getFlagMeta(RegionFlag.EXIT_COMMAND).execute(player);
+
+                if(!fromFlags.isEffectiveOwner(player) && fromFlags.hasFlag(RegionFlag.EXIT_GAMEMODE)) {
+                    player.setGameMode(fromFlags.<GameModeMeta>getFlagMeta(RegionFlag.EXIT_GAMEMODE).toGameMode());
+                }
             }
         }
     }
 
     /**
      * Grants the player permission to fly if they log into a region where the flight flag is set to true.
+     * Changes the player's gamemode if they log into a region with the entry-gamemode flag
      *
      * @param event the event.
      */
@@ -958,9 +988,15 @@ public class PlayerEventHandler implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (!event.getPlayer().isOp()) {
             FlagContainer flags = RegionProtection.getDataManager().getFlagsAt(event.getPlayer().getLocation());
-            if (flags != null)
+            if (flags != null) {
                 event.getPlayer().setAllowFlight(flags.isAllowed(RegionFlag.FLIGHT));
+
+                if (!flags.isEffectiveOwner(event.getPlayer()) && flags.hasFlag(RegionFlag.ENTRY_GAMEMODE)) {
+                    event.getPlayer().setGameMode(flags.<GameModeMeta>getFlagMeta(RegionFlag.ENTRY_GAMEMODE).toGameMode());
+                }
+            }
         }
+
     }
 
     /**


### PR DESCRIPTION
# Create entry-gamemode and exit-gamemode flags
## Flags that can change the gamemode of a player entering or exiting a region.
`entry-gamemode` - Changes to this gamemode whenever a player walks, teleports, respawns, or logs into a region.
`exit-gamemode` - Chages to this gamemode whenever a player dies or walks, teleports, or respawns away from a region.

### Usage:
`exit-gamemode`:
```
/region flag <region> set exit-gamemode <adventure|creative|spectator|survival>
```
`entry-gamemode`:
```
/region flag <region> set entry-gamemode <adventure|creative|spectator|survival>
```