### PR TITLE
Show claim names

### DIFF
--- a/src/com/kicas/rp/command/SimpleCommand.java
+++ b/src/com/kicas/rp/command/SimpleCommand.java
@@ -227,7 +227,8 @@ public class SimpleCommand extends TabCompleterBase implements CommandExecutor {
         claimlist.forEach(region -> {
             TextUtils.sendFormatted(
                     sender,
-                    "&(gold)%0x, %1z: {&(aqua)%2} claim blocks",
+                    "{&(green)%0}&(gold)%1x, %2z: {&(aqua)%3} claim blocks",
+                    region.getRawName() != null && !region.getRawName().isEmpty() ? region.getRawName() + ": " : "",
                     (int) (0.5 * (region.getMin().getX() + region.getMax().getX())),
                     (int) (0.5 * (region.getMin().getZ() + region.getMax().getZ())),
                     region.area()

--- a/src/com/kicas/rp/event/RegionToolHandler.java
+++ b/src/com/kicas/rp/event/RegionToolHandler.java
@@ -7,6 +7,7 @@ import com.kicas.rp.data.flagdata.TrustMeta;
 import com.kicas.rp.util.Materials;
 import com.kicas.rp.util.Pair;
 
+import com.kicas.rp.util.TextUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -278,14 +279,17 @@ public class RegionToolHandler implements Listener {
             // highlighter themselves.
             RegionProtection.getDataManager().getPlayerSession(recipient).setRegionHighlighter(null);
         } else {
-            String message = ChatColor.GOLD + "This belongs to " + claim.getOwnerName();
+            String message = "&(gold)This belongs to " + claim.getOwnerName();
             if (claim.isEffectiveOwner(recipient)) {
                 Pair<Location, Location> bounds = claim.getBounds();
                 message += ". This " + (claim.isAdminOwned() ? "region" : "claim") + " is " +
-                        ((int)(bounds.getSecond().getX() - bounds.getFirst().getX())) + " by " +
-                        ((int)(bounds.getSecond().getZ() - bounds.getFirst().getZ())) + " blocks.";
+                        ((int) (bounds.getSecond().getX() - bounds.getFirst().getX())) + " by " +
+                        ((int) (bounds.getSecond().getZ() - bounds.getFirst().getZ())) + " blocks. ";
+                if (claim.getRawName() != null && !claim.getRawName().isEmpty()) {
+                    message += "This " + (claim.isAdminOwned() ? "region" : "claim") + " is named \"" + claim.getRawName() + "\"";
+                }
             }
-            recipient.sendMessage(message);
+            TextUtils.sendFormatted(recipient, message);
             RegionProtection.getDataManager().getPlayerSession(recipient)
                     .setRegionHighlighter(new RegionHighlighter(recipient, claim, true));
         }


### PR DESCRIPTION
Show the names of claims in `/claimlist` and when the player uses a stick on their own claim.
## Named claims in `/claimlist`
![image](https://user-images.githubusercontent.com/70620591/100642707-bc781380-32fe-11eb-8452-4ab197c4e340.png)

## Right clicking on a region with the claim viewer tool
![image](https://user-images.githubusercontent.com/70620591/100642924-082abd00-32ff-11eb-8f5c-b00d5e660ee9.png)
Only shows the name if the player is an effective owner of the claim.
