### PR TITLE
Create modify-armor-stand flag

### DIFF
--- a/src/com/kicas/rp/data/RegionFlag.java
+++ b/src/com/kicas/rp/data/RegionFlag.java
@@ -75,7 +75,8 @@ public enum RegionFlag {
     FIRE_TICK(true),
     ENTRY_GAMEMODE(GameModeMeta.class),
     EXIT_GAMEMODE(GameModeMeta.class),
-    PLAYER_COLLISIONS;
+    PLAYER_COLLISIONS,
+    MODIFY_ARMOR_STANDS;
 
     public static final RegionFlag[] VALUES = values();
     private static final Map<RegionFlag, Pair<Object, Function<World, Object>>> DEFAULT_VALUES = new HashMap<>();
@@ -262,6 +263,7 @@ public enum RegionFlag {
         registerDefault(ENTRY_GAMEMODE, null);
         registerDefault(EXIT_GAMEMODE, null);
         registerDefault(PLAYER_COLLISIONS, true);
+        registerDefault(MODIFY_ARMOR_STANDS, false);
     }
 
     /**

--- a/src/com/kicas/rp/event/EntityEventHandler.java
+++ b/src/com/kicas/rp/event/EntityEventHandler.java
@@ -21,6 +21,8 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 
+import java.util.Objects;
+
 /**
  * Handles events caused or related to non-player entities.
  */
@@ -255,7 +257,8 @@ public class EntityEventHandler implements Listener {
             return;
         }
         // Stop all armor stands teleporting into another region when the armor statues datapack is installed
-        if(event.getEntity().getType().equals(EntityType.ARMOR_STAND) && toFlags != fromFlags &&
+        if(event.getEntity().getType().equals(EntityType.ARMOR_STAND) &&
+                !Objects.equals(toFlags, fromFlags) &&
                 Bukkit.getServer().getScoreboardManager().getMainScoreboard().getObjective("as_trigger") != null) {
             event.setCancelled(true);
             return;

--- a/src/com/kicas/rp/event/PlayerEventHandler.java
+++ b/src/com/kicas/rp/event/PlayerEventHandler.java
@@ -1012,8 +1012,8 @@ public class PlayerEventHandler implements Listener {
      */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
-        String message = event.getMessage().trim().replaceAll("^(/+)?", "");
         // Remove beginning /'s
+        String message = event.getMessage().trim().replaceAll("^(/+)?", "");
 
         // Go past the namespace if they do something like /minecraft:tp, and also find the end of the command
         int start = message.indexOf(':') + 1, end = message.indexOf(' ');
@@ -1075,7 +1075,9 @@ public class PlayerEventHandler implements Listener {
                                 event.getPlayer().sendMessage(ChatColor.RED + "This belongs to " + armorStandFlags.getOwnerName() + ".");
                             }
                             // If it's an admin claim and the player isn't an owner
-                            if(armorStandFlags.isAdminOwned() && !armorStandFlags.isEffectiveOwner(event.getPlayer())){
+                            if(armorStandFlags.isAdminOwned() &&
+                                    !armorStandFlags.isEffectiveOwner(event.getPlayer()) &&
+                                    !armorStandFlags.isAllowed(RegionFlag.MODIFY_ARMOR_STANDS)){
                                 event.setCancelled(true);
                                 event.getPlayer().sendMessage(ChatColor.RED + "You cannot modify that here.");
                             }


### PR DESCRIPTION
# Create `modify-armor-stand` flag
A flag that toggles whether or not a player is allowed to run commands from Vanilla Tweaks' "Armor Statues" Book.

### Values
Allow | Deny

### Default
Deny

## Note:
For players to use the book everywhere, you should set the flag to `allow` on `__global__`.  Without it, players will be able to edit armour stands until you add another flag on `__global__` at which point, you will have to have the flag in order for them to keep working.